### PR TITLE
Issue #5 Add per-author change statistics over time

### DIFF
--- a/helpers/report_helper.rb
+++ b/helpers/report_helper.rb
@@ -81,11 +81,19 @@ module ReportHelper
   end
 
   def histogram_chart(repository, method, heading, title, options = {})
-    render_chart "histogram_chart", repository, method, title, {heading: heading}.merge(options)
+    render_chart "histogram_chart", repository, method, title, heading_options(heading).merge(options)
   end
 
   def large_histogram_chart(repository, method, heading, title, options = {})
     histogram_chart(repository, method, heading, title, {width: 800, height: 600}.merge(options))
+  end
+
+  def heading_options(heading)
+    {
+      heading: heading,
+      vertical_heading: heading.respond_to?(:each) ? "Count" : heading,
+      stacked: false,
+    }
   end
 
   def table(repository, method, labels, limit = 30, options = {})

--- a/models/author.rb
+++ b/models/author.rb
@@ -14,16 +14,4 @@ class Author < ActiveRecord::Base
   def last_commit
     commits.last
   end
-
-  def commit_activity
-    @commit_activity ||= CommitActivity.new(self).call
-  end
-
-  def commits_per_day
-    @commits_per_day ||= CommitsPerDay.new(self).call
-  end
-
-  def commits_per_hour
-    @commits_per_hour ||= CommitsPerHour.new(self).call
-  end
 end

--- a/models/modules/analysed_commits.rb
+++ b/models/modules/analysed_commits.rb
@@ -2,4 +2,20 @@ module AnalysedCommits
   def analysed_commits
     commits.where.not(author_id: nil)
   end
+
+  def commit_activity
+    @commit_activity ||= CommitActivity.new(self).call
+  end
+
+  def commits_per_day
+    @commits_per_day ||= CommitsPerDay.new(self).call
+  end
+
+  def commits_per_hour
+    @commits_per_hour ||= CommitsPerHour.new(self).call
+  end
+
+  def changes_per_hour
+    @changes_per_hour ||= ChangesPerHour.new(self).call
+  end
 end

--- a/templates/authors_report/authors.html.haml
+++ b/templates/authors_report/authors.html.haml
@@ -4,13 +4,17 @@
 
 = scatter_chart(repository, :commit_activity, "Hour")
 
-%h2 Per Day
+%h2 Commits Per Day
 
 = histogram_chart(repository, :commits_per_day, "Commits", "Commits per Day")
 
-%h2 Per Hour
+%h2 Commits Per Hour
 
 = histogram_chart(repository, :commits_per_hour, "Commits", "Commits per Hour", width: 800, height: 300)
+
+%h2 Changes Per Hour
+
+= histogram_chart(repository, :changes_per_hour, ["Additions", "Deletions"], "Commits per Hour", width: 800, height: 300, vertical_heading: "Changes", stacked: true)
 
 %h2 Top Authors
 

--- a/templates/authors_report/authors_subreport.html.haml
+++ b/templates/authors_report/authors_subreport.html.haml
@@ -29,11 +29,15 @@
 
 = scatter_chart(author, :commit_activity, "Hour")
 
-%h2 Per Day
+%h2 Commits Per Day
 
 = histogram_chart(author, :commits_per_day, "Commits", "Commits per Day")
 
-%h2 Per Hour
+%h2 Commits Per Hour
 
 = histogram_chart(author, :commits_per_hour, "Commits", "Commits per Hour", width: 800, height: 300)
+
+%h2 Changes Per Hour
+
+= histogram_chart(author, :changes_per_hour, ["Additions", "Deletions"], "Commits per Hour", width: 800, height: 300, vertical_heading: "Changes", stacked: true)
 

--- a/templates/shared/histogram_chart.html.haml
+++ b/templates/shared/histogram_chart.html.haml
@@ -21,7 +21,7 @@
 
       // Create the data table.
       var data = google.visualization.arrayToDataTable([
-        ["Key", "#{heading}"],
+        ["Key", "#{heading.respond_to?(:each) ? heading.join("\", \"") : heading}"],
 
         #{
           data.map do |key, values|
@@ -35,8 +35,9 @@
       var options = {
         width: #{width},
         height: #{height},
+        isStacked: #{stacked},
         hAxis: {title: "#{title}"},
-        vAxis: {title: "#{heading}", minValue: 0},
+        vAxis: {title: "#{vertical_heading}", minValue: 0},
         chartArea: {width: "75%", height: "70%", left: 50, top: 25}
       };
 

--- a/transforms/changes_per_hour.rb
+++ b/transforms/changes_per_hour.rb
@@ -1,0 +1,25 @@
+class ChangesPerHour
+  include ReportHelper
+
+  attr_reader :repository_or_author
+
+  def initialize(repository_or_author)
+    @repository_or_author = repository_or_author
+  end
+
+  def call
+    result = {}
+
+    (0..23).each do |hour|
+      result["#{hour}h"] = [0, 0]
+    end
+
+    repository_or_author.analysed_commits.each do |commit|
+      hour = commit.date.hour
+      result["#{hour}h"][0] += commit.commit_diffs.sum(:added)
+      result["#{hour}h"][1] -= commit.commit_diffs.sum(:removed)
+    end
+
+    result
+  end
+end


### PR DESCRIPTION
Per hour, split into additions and deletions against the zero axis,
so that authors can get an idea of how much they add/delete and when
they do the most adding/deleting (perhaps they have a cycle of
refactoring).