### PR TITLE
Allow null parent hashes in commits

### DIFF
--- a/db/migrate/07_allow_null_commit_parent_hashes.rb
+++ b/db/migrate/07_allow_null_commit_parent_hashes.rb
@@ -1,0 +1,7 @@
+class AllowNullCommitParentHashes < ActiveRecord::Migration
+  def change
+    # For git projects initialised with git-svn it's possible to have
+    # a nil parent hash. See e.g. https://github.com/soundasleep/openclerk@69418e9e8c53ebe196ceadf68ff2ff54a0b261d1
+    change_column :commits, :parent_hashes, :string, :null => true
+  end
+end

--- a/models/commit.rb
+++ b/models/commit.rb
@@ -12,7 +12,7 @@ class Commit < ActiveRecord::Base
 
   default_scope { order('author_date ASC') }
 
-  validates :commit_hash, :short_hash, :tree_hash, :parent_hashes,
+  validates :commit_hash, :short_hash, :tree_hash,
       :author_name, :author_email, :author_date, :committer_name,
       :committer_email, :committer_date, :subject, presence: true
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -202,6 +202,20 @@ describe "Integration tests", type: :integration do
           end
         end
       end
+
+      describe "max = 1" do
+        let(:options) {
+          integration_options.merge({
+            limit: nil,
+            max: 1,
+          })
+        }
+
+        it "has analysed only one commit out of way more than 3 total" do
+          expect(repository.analysed_commits.size).to eq(1), "analysed commits = #{repository.analysed_commits.map(&:subject)}"
+          expect(repository.commits.size).to be > 3
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This can occur with git projects initialised with git-svn.

For example, see https://github.com/soundasleep/openclerk commit 69418e9e8c53ebe196ceadf68ff2ff54a0b261d1